### PR TITLE
Update env sample to use YOUR_SDK_KEY

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,3 @@
 # DevCycle SDK Key
 # This can be found in the DevCycle dashboard Settings under "Environments & Keys"
-DEVCYCLE_CLIENT_SDK_KEY="YOUR_KEY_HERE"
+DEVCYCLE_CLIENT_SDK_KEY="<YOUR_SDK_KEY>"


### PR DESCRIPTION
Updating example apps to use a consistent value in sample env files so that it can be easily replaced by the CLI